### PR TITLE
add no-aria-describedby rule and tests

### DIFF
--- a/src/rules/accessibility/no-aria-describedby.js
+++ b/src/rules/accessibility/no-aria-describedby.js
@@ -1,0 +1,17 @@
+HTMLHint.addRule({
+    id: 'no-aria-describedby',
+    description: '"aria-describedby" should never be used as inline attribute but via bindingHandler only',
+    init: function (parser, reporter) {
+        var self = this;
+
+        var hasAriaDescribedbyAttr = function (event) {
+            return HTMLHint.utils.isAttributeExists(event.attrs, "aria-describedby");
+        };
+
+        parser.addListener('tagstart', function (event) {
+            if (hasAriaDescribedbyAttr(event)) {
+                reporter.error('"aria-describedby" should not be used as inline attribute', event.line, event.col, self, event.raw);
+            }
+        });
+    }
+});

--- a/test/rules/accessibility/no-aria-describedby.spec.js
+++ b/test/rules/accessibility/no-aria-describedby.spec.js
@@ -1,0 +1,33 @@
+var expect  = require("expect.js");
+
+var HTMLHint  = require("../../../index").HTMLHint;
+
+var ruldId = 'no-aria-describedby',
+    ruleOptions = {};
+
+ruleOptions[ruldId] = true;
+
+describe('Rules: '+ruldId, function(){
+
+    it('input with aria-describedby attribute should reslt in an error', function(){
+        var code = '<input  type="text" />';
+        var messages = HTMLHint.verify(code, ruleOptions);
+        expect(messages.length).to.be(1);
+        expect(messages[0].rule.id).to.be(ruldId);
+        expect(messages[0].line).to.be(1);
+        expect(messages[0].col).to.be(1);   
+    });
+
+    it('input without aria-describedby attribute should not reslt in an error', function(){
+       var code = '<input type="text"/>';
+        var messages = HTMLHint.verify(code, ruleOptions);
+        expect(messages.length).to.be(0);
+    });
+
+     it('input with aria-describedby via binding handler should not reslt in an error', function(){
+       var code = '<input type="text" data-bind="addDescription"/>';
+        var messages = HTMLHint.verify(code, ruleOptions);
+        expect(messages.length).to.be(0);
+    });
+
+});

--- a/test/rules/accessibility/no-aria-describedby.spec.js
+++ b/test/rules/accessibility/no-aria-describedby.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = true;
 describe('Rules: '+ruldId, function(){
 
     it('input with aria-describedby attribute should reslt in an error', function(){
-        var code = '<input  type="text" />';
+        var code = '<input  type="text" aria-describedby="desc"/>';
         var messages = HTMLHint.verify(code, ruleOptions);
         expect(messages.length).to.be(1);
         expect(messages[0].rule.id).to.be(ruldId);


### PR DESCRIPTION
aria-describedby can be set with multiple id's
therefore must be added with bindingHandler so it will not override other values that might be set somewhere in code.